### PR TITLE
Fix problems with Keras 2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Introduction
-One of the longstanding goals of computer vision is to automatically infer *what* things are in an image, and *where* those things are located.
-In particular, the problem of semantic segmentation is to infer the category of each pixel in an image.
-It is too difficult to directly program a computer to do this,
-so machine learning is used to search for a model that is good at this task.
+A key task in computer vision is semantic segmentation, which attempts to simultaneously answer the questions of what is in an image, and where it is located. More formally, the task is to assign to each pixel a meaningful label such as "road" or "building."
 
 This repo contains code for semantic segmentation using convolutional neural networks built on top of the [Keras](https://keras.io/) and [Tensorflow](https://www.tensorflow.org/) libraries.
 There is code for building Docker containers, running experiments on AWS EC2, loading data, training models, and evaluating models on validation and test data.
@@ -33,6 +30,8 @@ The following datasets and model architectures are implemented.
 
 - Vagrant 1.8+
 - VirtualBox 4.3+
+- Python 2.7
+- Ansible 2.1+
 
 ### Scripts
 
@@ -81,10 +80,11 @@ After following the link to the Potsdam dataset, download
 `1_DSM_normalisation.zip`, `4_Ortho_RGBIR.zip`, `5_Labels_for_participants.zip`, and `5_Labels_for_participants_no_Boundary.zip`. Then unzip the files into
 `/opt/data/datasets/potsdam`, resulting in `/opt/data/datasets/potsdam/1_DSM_normalisation/`, etc.
 
-TODO: instructions for Vaihingen
+For the [ISPRS 2D Semantic Labeling Vaihingen dataset](http://www2.isprs.org/commissions/comm3/wg4/2d-sem-label-vaihingen.html) dataset, download `ISPRS_semantic_labeling_Vaihingen.zip` and `ISPRS_semantic_labeling_Vaihingen_ground_truth_eroded_for_participants.zip`. Then unzip the files into `/opt/data/datasets/vaihingen`, resulting in
+`/opt/data/datasets/vaihingen/dsm`, `/opt/data/datasets/vaihingen/gts_for_participants`, etc.
 
-Then run `python -m semseg.data.factory --preprocess`. This will generate `/opt/data/datasets/processed_potsdam`. As a test, you may want to run `python -m semseg.data.factory --plot` which will generate PDF files that visualize samples produced by the data generator in  `/opt/data/results/gen_samples/`.
- To make the processed data available for use on EC2, upload a zip file of `/opt/data/datasets/processed_potsdam` named `processed_potsdam.zip` to the `otid-data` bucket.
+Then run `python -m semseg.data.factory --preprocess`. This takes about 15 minutes and will generate `/opt/data/datasets/processed_potsdam` and `/opt/data/datasets/processed_vaihingen`. As a test, you may want to run `python -m semseg.data.factory --plot` which will generate PDF files that visualize samples produced by the data generator in  `/opt/data/results/gen_samples/`.
+ To make the processed data available for use on EC2, upload a zip file of `/opt/data/datasets/processed_potsdam` named `processed_potsdam.zip` (and similar for Vaihingen) to the `otid-data` bucket.
 
 ### Running experiments
 
@@ -124,7 +124,7 @@ After initializing, the instance should have `nvidia-docker`, the GPU-enabled Do
 After starting an instance, `ssh` into it with
 ```shell
 ssh-add ~/.aws/open-tree-id.pem
-ssh ubuntu@<public dns>
+ssh ec2-user@<public dns>
 ```
 
 Then you can train a model with

--- a/deployment/terraform/config-ec2
+++ b/deployment/terraform/config-ec2
@@ -1,23 +1,32 @@
 #!/bin/bash
 
-cd /home/ubuntu
+cd /home/ec2-user
 
 # Install command line tools
-apt-get install -y awscli git unzip
+sudo yum install -y aws-cli git unzip
+
+# Install nvidia-docker and nvidia-docker-plugin
+wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1_amd64.tar.xz
+sudo tar --strip-components=1 -C /usr/bin -xvf /tmp/nvidia-docker*.tar.xz && rm /tmp/nvidia-docker*.tar.xz
+
+# Run nvidia-docker-plugin
+sudo -b nohup nvidia-docker-plugin > /tmp/nvidia-docker.log
 
 # Copy data
 aws s3 cp s3://otid-data/processed_potsdam.zip data/datasets/processed_potsdam.zip
 pushd data/datasets
-unzip -q -o processed_potsdam.zip
+unzip processed_potsdam.zip
+rm processed_potsdam.zip
 popd
 
 aws s3 cp s3://otid-data/processed_vaihingen.zip data/datasets/processed_vaihingen.zip
 pushd data/datasets
-unzip -q -o processed_vaihingen.zip
+unzip processed_vaihingen.zip
+rm processed_vaihingen.zip
 popd
 
 # Download source repo
-sudo -H -u ubuntu bash -c "yes | git clone https://github.com/azavea/keras-semantic-segmentation.git"
+sudo -H -u ec2-user bash -c "yes | git clone https://github.com/azavea/keras-semantic-segmentation.git"
 
 # Get docker container
 `aws ecr get-login --region us-east-1`

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -31,5 +31,5 @@ variable "fleet_security_group_id" {
 }
 
 variable "fleet_ami" {
-  default = "ami-50b4f047"
+  default = "ami-917eec87"
 }

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -1,5 +1,5 @@
 # Based on https://github.com/fchollet/keras/blob/2b51317be82d4420169d2cc79dc4443028417911/docker/Dockerfile
-FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu14.04
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu14.04
 
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH

--- a/src/Dockerfile-gpu
+++ b/src/Dockerfile-gpu
@@ -6,9 +6,8 @@ USER keras
 # Python
 
 ARG tensorflow_version=1.0.1-cp35-cp35m
-ARG architecture=gpu
 
-RUN pip install https://storage.googleapis.com/tensorflow/linux/${architecture}/tensorflow-${tensorflow_version}-linux_x86_64.whl && \
+RUN pip install https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${tensorflow_version}-linux_x86_64.whl && \
     pip install git+git://github.com/fchollet/keras.git@7c6463da6f972ffaa466b0f55d06b760a98caf8e
 
 WORKDIR /opt/src

--- a/src/experiments/tests/quick_test.json
+++ b/src/experiments/tests/quick_test.json
@@ -15,6 +15,6 @@
     "nb_labels": 6,
     "validation_steps": 1,
     "nb_eval_samples": 1,
-    "run_name": "quick_test",
+    "run_name": "tests/quick_test",
     "steps_per_epoch": 2
 }

--- a/src/semseg/data/factory.py
+++ b/src/semseg/data/factory.py
@@ -48,10 +48,11 @@ def plot_generator(dataset_name, generator_name, split):
         def __init__(self):
             self.dataset_name = dataset_name
             self.generator_name = generator_name
-            self.include_ir = True
-            self.include_depth = True
-            self.include_ndvi = True
-            self.train_ratio = 0.7
+            self.active_input_inds = [0, 1, 2, 3]
+            if dataset_name == POTSDAM:
+                self.active_input_inds = [0, 1, 2, 3, 4]
+            self.train_ratio = 0.8
+            self.cross_validation = None
 
     options = Options()
     generator = get_data_generator(options, datasets_path)

--- a/src/semseg/data/potsdam.py
+++ b/src/semseg/data/potsdam.py
@@ -149,8 +149,7 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
         _makedirs(proc_data_path)
 
         generator = PotsdamImageFileGenerator(
-            datasets_path, include_ir=True, include_depth=True,
-            include_ndvi=False)
+            datasets_path, [0, 1, 2, 3, 4])
         dataset = generator.dataset
 
         def _preprocess(split):
@@ -158,17 +157,17 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
                 split, batch_size=1, shuffle=False, augment=False,
                 normalize=False, eval_mode=True)
 
-            for batch_x, batch_y, batch_y_mask, file_inds in gen:
-                file_ind = file_inds[0]
-
-                batch_x = np.squeeze(batch_x, axis=0)
-                channels = [batch_x]
+            for (batch_x, batch_y, all_batch_x, batch_y_mask,
+                    batch_file_inds) in gen:
+                file_ind = batch_file_inds[0]
+                x = np.squeeze(batch_x, axis=0)
+                channels = [x]
 
                 if batch_y is not None:
-                    batch_y = np.squeeze(batch_y, axis=0)
-                    batch_y = dataset.one_hot_to_label_batch(batch_y)
-                    batch_y_mask = np.squeeze(batch_y_mask, axis=0)
-                    channels.extend([batch_y, batch_y_mask])
+                    y = np.squeeze(batch_y, axis=0)
+                    y = dataset.one_hot_to_label_batch(y)
+                    y_mask = np.squeeze(batch_y_mask, axis=0)
+                    channels.extend([y, y_mask])
                 channels = np.concatenate(channels, axis=2)
 
                 ind0, ind1 = file_ind
@@ -178,9 +177,9 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
 
                 # Free memory
                 channels = None
-                batch_x = None
-                batch_y = None
-                batch_y_mask = None
+                batch_x = x = None
+                batch_y = y = None
+                batch_y_mask = y_mask = None
 
         _preprocess(TRAIN)
         _preprocess(VALIDATION)

--- a/src/semseg/data/vaihingen.py
+++ b/src/semseg/data/vaihingen.py
@@ -123,8 +123,7 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
         _makedirs(proc_data_path)
 
         generator = VaihingenImageFileGenerator(
-            datasets_path, include_depth=True,
-            include_ndvi=False)
+            datasets_path, [0, 1, 2, 3])
         dataset = generator.dataset
 
         def _preprocess(split):
@@ -132,17 +131,17 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
                 split, batch_size=1, shuffle=False, augment=False,
                 normalize=False, eval_mode=True)
 
-            for batch_x, batch_y, batch_y_mask, file_inds in gen:
-                file_ind = file_inds[0]
-
-                batch_x = np.squeeze(batch_x, axis=0)
-                channels = [batch_x]
+            for (batch_x, batch_y, all_batch_x, batch_y_mask,
+                    batch_file_inds) in gen:
+                file_ind = batch_file_inds[0]
+                x = np.squeeze(batch_x, axis=0)
+                channels = [x]
 
                 if batch_y is not None:
-                    batch_y = np.squeeze(batch_y, axis=0)
-                    batch_y = dataset.one_hot_to_label_batch(batch_y)
-                    batch_y_mask = np.squeeze(batch_y_mask, axis=0)
-                    channels.extend([batch_y, batch_y_mask])
+                    y = np.squeeze(batch_y, axis=0)
+                    y = dataset.one_hot_to_label_batch(y)
+                    y_mask = np.squeeze(batch_y_mask, axis=0)
+                    channels.extend([y, y_mask])
                 channels = np.concatenate(channels, axis=2)
 
                 file_name = '{}'.format(file_ind)
@@ -151,9 +150,9 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
 
                 # Free memory
                 channels = None
-                batch_x = None
-                batch_y = None
-                batch_y_mask = None
+                batch_x = x = None
+                batch_y = y = None
+                batch_y_mask = y_mask = None
 
         _preprocess(TRAIN)
         _preprocess(VALIDATION)


### PR DESCRIPTION
This PR adds a bunch of fixes so that Keras 2 and Tensorflow 1 will work locally and on EC2. To do this, we're using a custom AMI that is based on ECS optimized Amazon Linux with NVIDIA drivers 375.51. We had to create a custom AMI because installing the drivers requires multiple reboots. It also fixes some broken functionality around preprocessing and plotting data, and updates the README.